### PR TITLE
Update mTwitch.StateToTopic.mrc

### DIFF
--- a/mTwitch.StateToTopic.mrc
+++ b/mTwitch.StateToTopic.mrc
@@ -1,5 +1,5 @@
 alias mTwitch.has.StateToTopic {
-  0000.0000.0009
+  return 0000.0000.0010
 }
 
 alias mTwitch.StateToTopic {


### PR DESCRIPTION
return was missing for mTwitch.has.StateToTopic alias
